### PR TITLE
Fix typo in Japanese spell of 'Scrum'

### DIFF
--- a/i18n/jp.yml
+++ b/i18n/jp.yml
@@ -20,7 +20,7 @@ overview:
   scrum_overview_picture: スクラム概要の絵
   overview_picture_pdf_versions: スクラム概要PDF
   scrum_overview_v1: スクラム概要バージョン１
-  scrum_overview_v2: スクラクム概要バージョン２
+  scrum_overview_v2: スクラム概要バージョン２
   feel_free_to_use: このコンテンツはご自由にお使い下さい
   work_is_licensed_under: コンテンツのライセンスについては下記をご確認下さい 
 


### PR DESCRIPTION
There is a wrong spelled "Scrum" in Japanese. (We read this 'scrucm')