### PR TITLE
Fix failing build on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ before_install:
   - export PATH=$PATH:/tmp
   - gem update
   - gem install bundler
-  - pip install robotframework
-  - pip install robotframework-selenium2library
+  - pip install --user robotframework
+  - pip install --user robotframework-selenium2library
 
 before_script:
   - google-chrome --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,14 @@ addons:
 before_install:
   - wget https://chromedriver.storage.googleapis.com/2.27/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip -d /tmp
-  - export PATH=$PATH:/tmp
+  - export PATH=$HOME/.local/bin:$PATH:/tmp
   - gem update
   - gem install bundler
+  - pip --version
+  - pip install --user --upgrade pip
+  - pip install --user --upgrade urllib3
+  - pip --version
+  - pip freeze
   - pip install --user robotframework
   - pip install --user robotframework-selenium2library
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
       - google-chrome-stable
 
 before_install:
-  - wget https://chromedriver.storage.googleapis.com/2.27/chromedriver_linux64.zip
+  - wget https://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip -d /tmp
   - export PATH=$HOME/.local/bin:$PATH:/tmp
   - gem update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 dist: trusty
+language: ruby
+cache: bundler
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - sh -e /etc/init.d/xvfb start
 
 rvm:
-  - 2.1
+  - 2.3.1
 
 python:
   - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,8 @@ before_install:
   - export PATH=$HOME/.local/bin:$PATH:/tmp
   - gem update
   - gem install bundler
-  - pip --version
   - pip install --user --upgrade pip
   - pip install --user --upgrade urllib3
-  - pip --version
-  - pip freeze
   - pip install --user robotframework
   - pip install --user robotframework-selenium2library
 

--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ RSpec::Core::RakeTask.new(:integration) do |t|
 end
 
 task :robot_tests do
-	sh "pybot -d robottests/output --noncritical 'developing' robottests"
+	sh "robot -d robottests/output --noncritical 'developing' robottests"
 end
 
 desc "run cucumber features"


### PR DESCRIPTION
Changes include:
- using ruby 2.3.1 (from .ruby-version)
- pip install on local user
- changing pybot to robot as pybot command is obsoleted
- upgrade chromedriver version to fix a failing build
- add bundler caching
- clean up debugging information (`pip --version` and `pip freeze`)